### PR TITLE
Fix Change Password overlay silently failing validation

### DIFF
--- a/Sources/Client/Overlay_ChangePassword.h
+++ b/Sources/Client/Overlay_ChangePassword.h
@@ -40,6 +40,9 @@ private:
     int m_iPrevFocus;
     int m_iMaxFocus;
 
+    // Error feedback
+    std::string m_error_msg;
+
     // Timing
     uint32_t m_dwStartTime = 0;
     uint32_t m_dwAnimTime = 0;


### PR DESCRIPTION
The Change Password overlay appeared non-functional because validate_inputs() returned false with no user feedback — all validation errors were invisible. Also, end_input_string() was called after validation, meaning the active input field's buffer hadn't been finalized when checks ran.

- Moved end_input_string() before validation so buffer content is committed
- Replaced silent validate_inputs() with inline checks that set m_error_msg
- Added red error text display in on_render() (centered at help text position)
- Clear error message when user clicks back into any input field