### PR TITLE
Fix chat input cancelled when opening dialogs, add Escape to close chat

### DIFF
--- a/Sources/Client/DialogBoxManager.cpp
+++ b/Sources/Client/DialogBoxManager.cpp
@@ -856,6 +856,12 @@ void DialogBoxManager::enable_dialog_box(int box_id, int type, int v1, int v2, c
 		}
 		break;
 
+	// These dialogs should not cancel text input when toggled
+	case DialogBoxId::CharacterInfo:
+	case DialogBoxId::Inventory:
+	case DialogBoxId::ChatHistory:
+		break;
+
 	default:
 		text_input_manager::get().end_input();
 		if (is_enabled(box_id) == false) {

--- a/Sources/Client/Game.Hotkeys.cpp
+++ b/Sources/Client/Game.Hotkeys.cpp
@@ -472,6 +472,14 @@ void CGame::hotkey_simple_escape()
 	// Note: Escape handling is automatic through hb::shared::input::is_key_pressed(KeyCode::Escape)
 	if (GameModeManager::get_mode() == GameMode::MainGame)
 	{
+		// Cancel active chat input
+		if (text_input_manager::get().is_active())
+		{
+			m_chat_msg.clear();
+			text_input_manager::get().end_input();
+			return;
+		}
+
 		if ((m_is_observer_mode == true) && (hb::shared::input::is_shift_down())) {
 			if (m_logout_count == -1) m_logout_count = 1;
 			m_dialog_box_manager.disable_dialog_box(DialogBoxId::SystemMenu);


### PR DESCRIPTION
CharacterInfo (F5), Inventory (F6), and ChatHistory (F9) had no explicit case in the enable_dialog_box switch, so they fell through to default: which calls end_input() — closing any active chat input whenever these dialogs were toggled.

Added explicit empty case labels for CharacterInfo, Inventory, and ChatHistory to prevent them from reaching the default branch.

Also added Escape key support to cancel active chat input — pressing Escape while typing clears the message and closes the input field.