### PR TITLE
Fix item upgrade dialog — stone detection, majestic validation, and r…

### DIFF
--- a/Sources/Client/DialogBoxManager.cpp
+++ b/Sources/Client/DialogBoxManager.cpp
@@ -751,41 +751,7 @@ void DialogBoxManager::enable_dialog_box(int box_id, int type, int v1, int v2, c
 			Info(DialogBoxId::ItemUpgrade).m_v1 = -1;
 			Info(DialogBoxId::ItemUpgrade).m_dw_v1 = 0;
 		}
-		else
-		{
-			// Clear disabled flag for any item currently in the dialog before resetting
-			{ int old_idx = Info(DialogBoxId::ItemUpgrade).m_v1;
-			if (old_idx >= 0 && old_idx < hb::shared::limits::MaxItems) m_game->m_is_item_disabled[old_idx] = false; }
-			int so_x, so_m;
-			so_x = so_m = 0;
-			for (i = 0; i < hb::shared::limits::MaxItems; i++)
-				if (m_game->m_item_list[i] != 0)
-				{
-					if ((m_game->m_item_list[i]->m_sprite == 6) && (m_game->m_item_list[i]->m_sprite_frame == 128)) so_x++;
-					if ((m_game->m_item_list[i]->m_sprite == 6) && (m_game->m_item_list[i]->m_sprite_frame == 129)) so_m++;
-				}
-			if ((so_x > 0) || (so_m > 0))
-			{
-				Info(DialogBoxId::ItemUpgrade).m_mode = 6; // Stone upgrade
-				Info(DialogBoxId::ItemUpgrade).m_v2 = so_x;
-				Info(DialogBoxId::ItemUpgrade).m_v3 = so_m;
-				Info(DialogBoxId::ItemUpgrade).m_v1 = -1;
-				Info(DialogBoxId::ItemUpgrade).m_dw_v1 = 0;
-			}
-			else if (m_game->m_gizon_item_upgrade_left > 0)
-			{
-				Info(DialogBoxId::ItemUpgrade).m_mode = 1;
-				Info(DialogBoxId::ItemUpgrade).m_v2 = -1;
-				Info(DialogBoxId::ItemUpgrade).m_v3 = -1;
-				Info(DialogBoxId::ItemUpgrade).m_v1 = -1;
-				Info(DialogBoxId::ItemUpgrade).m_dw_v1 = 0;
-			}
-			else
-			{
-				m_game->add_event_list(DRAW_DIALOGBOX_ITEMUPGRADE30, 10); // "Stone of Xelima or Merien is not present."
-				return;
-			}
-		}
+		// If already open, do nothing (matches original behavior)
 		break;
 
 	case DialogBoxId::MagicShop:

--- a/Sources/Client/DialogBox_ItemUpgrade.cpp
+++ b/Sources/Client/DialogBox_ItemUpgrade.cpp
@@ -458,8 +458,10 @@ bool DialogBox_ItemUpgrade::on_click(short mouse_x, short mouse_y)
             for (int i = 0; i < hb::shared::limits::MaxItems; i++)
                 if (m_game->m_item_list[i] != 0)
                 {
-                    if ((m_game->m_item_list[i]->m_sprite == 6) && (m_game->m_item_list[i]->m_sprite_frame == 128)) so_x++;
-                    if ((m_game->m_item_list[i]->m_sprite == 6) && (m_game->m_item_list[i]->m_sprite_frame == 129)) so_m++;
+                    CItem* cfg = m_game->get_item_config(m_game->m_item_list[i]->m_id_num);
+                    if (!cfg) continue;
+                    if ((cfg->m_sprite == 6) && (cfg->m_sprite_frame == 128)) so_x++;
+                    if ((cfg->m_sprite == 6) && (cfg->m_sprite_frame == 129)) so_m++;
                 }
 
             if ((so_x > 0) || (so_m > 0))
@@ -469,14 +471,25 @@ bool DialogBox_ItemUpgrade::on_click(short mouse_x, short mouse_y)
                 m_game->m_dialog_box_manager.Info(DialogBoxId::ItemUpgrade).m_v3 = so_m;
             }
             else
+            {
                 m_game->add_event_list(DRAW_DIALOGBOX_ITEMUPGRADE30, 10);
+                m_game->m_dialog_box_manager.disable_dialog_box(DialogBoxId::ItemUpgrade);
+            }
             return true;
         }
         // Majestic item upgrade (Gizon)
         if ((mouse_x > sX + 24) && (mouse_x < sX + 248) && (mouse_y > sY + 120) && (mouse_y < sY + 135))
         {
-            m_game->m_dialog_box_manager.Info(DialogBoxId::ItemUpgrade).m_mode = 1;
             m_game->play_game_sound('E', 14, 5);
+            if (m_game->m_gizon_item_upgrade_left > 0)
+            {
+                m_game->m_dialog_box_manager.Info(DialogBoxId::ItemUpgrade).m_mode = 1;
+            }
+            else
+            {
+                m_game->add_event_list(DRAW_DIALOGBOX_ITEMUPGRADE40, 10);
+                m_game->m_dialog_box_manager.disable_dialog_box(DialogBoxId::ItemUpgrade);
+            }
             return true;
         }
         // Cancel


### PR DESCRIPTION
…e-open reset

- Stone detection used m_item_list[i]->m_sprite which is always 0 (inventory items don't carry sprite data). Now uses get_item_config() to read sprite values from the item config database, matching the rest of the codebase.
- Majestic upgrade (mode 1) was accessible from the selection screen without checking gizon points. Players with stones but no gizon could drop common items and the server would upgrade them using stones. Now checks m_gizon_item_upgrade_left > 0 before entering mode 1.
- Re-opening an already-open upgrade dialog reset mode and item state, causing the placed item to become permanently disabled. Removed the else-branch in enable_dialog_box to match original behavior (do nothing if already open).
- Normal upgrade with no stones now closes the dialog after showing the error message, preventing repeated clicks from spamming the message.