### PR TITLE
Fix pickup animation canceled by right-click rotation

### DIFF
--- a/Sources/Client/Game.cpp
+++ b/Sources/Client/Game.cpp
@@ -6298,7 +6298,8 @@ void CGame::command_processor(short mouse_x, short mouse_y, short tile_x, short 
 			int yc = m_player->m_player_y - m_map_data->m_pivot_y;
 			if (xc >= 0 && xc < MapDataSizeX && yc >= 0 && yc < MapDataSizeY) {
 				int8_t animAction = m_map_data->m_data[xc][yc].m_animation.m_action;
-				if (animAction == Type::Attack || animAction == Type::AttackMove || animAction == Type::Magic)
+				if (animAction == Type::Attack || animAction == Type::AttackMove || animAction == Type::Magic
+				|| animAction == Type::GetItem || animAction == Type::Damage || animAction == Type::DamageMove)
 					return;
 			}
 			direction = CMisc::get_next_move_dir(m_player->m_player_x, m_player->m_player_y, tile_x, tile_y);


### PR DESCRIPTION
With quick actions enabled, right-click rotation is allowed when the controller command is STOP. The animation filter already blocked rotation during Attack, AttackMove, and Magic animations, but GetItem was missing. Since the controller command resets to STOP after dispatching the pickup, right-click passed the check and allowed turning mid-pickup.

Added GetItem, Damage, and DamageMove to the animation filter for consistency with the damage stun system.