### PR TITLE
Fix cursor showing pickup hand instead of target on mob+item tiles

### DIFF
--- a/Sources/Client/CursorTarget.cpp
+++ b/Sources/Client/CursorTarget.cpp
@@ -90,25 +90,23 @@ void CursorTarget::end_frame(EntityRelationship relationship, int commandType, b
         }
     }
 
-    // Ground item cursor - only when NOT in spell targeting mode
+    // Entity focus takes priority — mobs/NPCs/players over ground items
+    if (s_focusedObject.m_valid) {
+        if (IsHostile(relationship) || hb::shared::input::is_ctrl_down())
+            s_cursorType = CursorType::TargetHostile;
+        else
+            s_cursorType = CursorType::TargetNeutral;
+        return;
+    }
+
+    // Ground item cursor - only when no entity is focused on the tile
     if (s_overGroundItem) {
-        // Animate every 200ms
         if (now - s_itemAnimTime > 200) {
             s_itemAnimTime = now;
             s_itemAnimFrame = (s_itemAnimFrame == 1) ? 2 : 1;
         }
         s_cursorType = (s_itemAnimFrame == 1) ?
             CursorType::ItemGround1 : CursorType::ItemGround2;
-        return;
-    }
-
-    // Normal mode - show target cursor based on focus
-    if (s_focusedObject.m_valid) {
-        // Holding Control treats neutral targets as hostile (for force-attack)
-        if (IsHostile(relationship) || hb::shared::input::is_ctrl_down())
-            s_cursorType = CursorType::TargetHostile;
-        else
-            s_cursorType = CursorType::TargetNeutral;
         return;
     }
 


### PR DESCRIPTION
The ground item check (s_overGroundItem) was evaluated before the focused entity check (s_focusedObject.valid) and returned early, so when a mob and an item drop occupied the same tile, the cursor always showed the pickup hand.

Swapped the priority order in CursorTarget::end_frame() so entities (mobs, NPCs, players) are checked first. The pickup cursor only appears when no entity is focused on that tile.