### PR TITLE
Fix Angelic Pendant misaligned in certain directions

### DIFF
--- a/Sources/Client/Game.cpp
+++ b/Sources/Client/Game.cpp
@@ -8313,15 +8313,6 @@ void CGame::check_active_aura2(short sX, short sY, uint32_t time, short owner_ty
 
 void CGame::draw_angel(int sprite, short sX, short sY, char frame, uint32_t time)
 {
-	switch (m_entity_state.m_dir)
-	{
-	case 1:
-	case 2:
-	case 7:
-	case 8:
-		sX -= 30;
-		break;
-	}
 	if (m_entity_state.m_status.invisibility)
 	{
 		if (m_entity_state.m_status.angel_str)


### PR DESCRIPTION
The refactored draw_angel() had a direction-based switch that shifted sX by -30 for directions 1, 2, 7, 8. This offset does not exist in the original code — DrawAngel() simply draws at the passed-in coordinates without any direction adjustment.

Removed the spurious direction switch, restoring original behavior where the pendant position is determined entirely by the caller's sX/sY offsets.