### PR TITLE
# Fix Hero Set contribution not refreshing (Issue #199)

### DIFF
--- a/Sources/Client/NetworkMessageManager.cpp
+++ b/Sources/Client/NetworkMessageManager.cpp
@@ -160,9 +160,9 @@ namespace NetworkMessageHandlers {
 	void HandlePKcaptured(CGame* game, char* data);
 	void HandlePKpenalty(CGame* game, char* data);
 	void HandleEnemyKills(CGame* game, char* data);
+	void HandleContribution(CGame* game, char* data);
 #ifdef TESTER_ONLY
 	// TESTER MENU — notification handlers (tester builds only)
-	void HandleContribution(CGame* game, char* data);
 	void HandleTesterItemSearchResult(CGame* game, char* data);
 	void HandleTesterMapListResult(CGame* game, char* data);
 #endif // TESTER_ONLY
@@ -331,10 +331,7 @@ bool NetworkMessageManager::process_message(uint32_t msg_id, char* data, uint32_
 		case Notify::PkCaptured: NetworkMessageHandlers::HandlePKcaptured(m_game, data); return true;
 		case Notify::PkPenalty: NetworkMessageHandlers::HandlePKpenalty(m_game, data); return true;
 		case Notify::EnemyKills: NetworkMessageHandlers::HandleEnemyKills(m_game, data); return true;
-#ifdef TESTER_ONLY
-		// TESTER MENU — contribution notify (tester builds only)
 		case Notify::Contribution: NetworkMessageHandlers::HandleContribution(m_game, data); return true;
-#endif // TESTER_ONLY
 		case Notify::EnemyKillReward: NetworkMessageHandlers::HandleEnemyKillReward(m_game, data); return true;
 		case Notify::GlobalAttackMode: NetworkMessageHandlers::HandleGlobalAttackMode(m_game, data); return true;
 		case Notify::DamageMove: NetworkMessageHandlers::HandleDamageMove(m_game, data); return true;

--- a/Sources/Client/NetworkMessages_Combat.cpp
+++ b/Sources/Client/NetworkMessages_Combat.cpp
@@ -102,8 +102,6 @@ namespace NetworkMessageHandlers {
 		game->m_player->m_enemy_kill_count = pkt->count;
 	}
 
-#ifdef TESTER_ONLY
-	// TESTER MENU — notification handlers (tester builds only)
 	void HandleContribution(CGame* game, char* data)
 	{
 		const auto* pkt = hb::net::PacketCast<hb::net::PacketNotifySimpleInt>(
@@ -112,6 +110,8 @@ namespace NetworkMessageHandlers {
 		game->m_player->m_contribution = pkt->value;
 	}
 
+#ifdef TESTER_ONLY
+	// TESTER MENU — notification handlers (tester builds only)
 	void HandleTesterItemSearchResult(CGame* game, char* data)
 	{
 		const auto* pkt = hb::net::PacketCast<hb::net::PacketNotifyTesterItemSearchResult>(

--- a/Sources/Server/ItemManager.cpp
+++ b/Sources/Server/ItemManager.cpp
@@ -3848,6 +3848,7 @@ void ItemManager::get_hero_mantle_handler(int client_h, int item_id, const char*
 				}
 
 				m_game->send_notify_msg(0, client_h, Notify::EnemyKills, m_game->m_client_list[client_h]->m_enemy_kill_count, 0, 0, 0);
+				m_game->send_notify_msg(0, client_h, Notify::Contribution, m_game->m_client_list[client_h]->m_contribution, 0, 0, 0);
 			}
 			else
 			{


### PR DESCRIPTION
- Server now sends Notify::Contribution after hero item creation in ItemManager
- Moved HandleContribution out of TESTER_ONLY guard so all builds receive the update
- Contribution points now refresh immediately in the F5 dialog without relog/map change